### PR TITLE
Manter o mesmo nome da propriedade

### DIFF
--- a/src/XsdConverter/Naming/SpedStrategy.php
+++ b/src/XsdConverter/Naming/SpedStrategy.php
@@ -30,7 +30,7 @@ class SpedStrategy implements NamingStrategy
      */
     public function getPropertyName($item)
     {
-        return Inflector::camelize(str_replace(".", " ", $item->getName()));
+        return str_replace(".", " ", $item->getName());
     }
 
     private function classify($name)


### PR DESCRIPTION
As propriedades das classes PHP podem permanecer com o mesmo nome, viabilizando a serialização dos objetos sem a necessidade de criar conversores de nomes.